### PR TITLE
made the NettyServerHandler callback take a reference to a MessageSender

### DIFF
--- a/src/main/java/com/mycodefu/vsssfshss/Entrypoint.java
+++ b/src/main/java/com/mycodefu/vsssfshss/Entrypoint.java
@@ -1,5 +1,6 @@
 package com.mycodefu.vsssfshss;
 
+import com.mycodefu.vsssfshss.server.MessageSender;
 import com.mycodefu.vsssfshss.server.NettyServer;
 import com.mycodefu.vsssfshss.server.NettyServerHandler;
 import io.netty.buffer.ByteBuf;
@@ -11,13 +12,14 @@ public class Entrypoint {
                 new NettyServer(8080, new NettyServerHandler.ServerConnectionCallback() {
 
                     @Override
-                    public void serverConnectionOpened(ChannelId id, String remoteAddress) {
+                    public void serverConnectionOpened(ChannelId id, MessageSender messageSender,
+                            String remoteAddress) {
 
                     }
 
                     @Override
-                    public void serverConnectionMessage(ChannelId id, String sourceIpAddress,
-                            ByteBuf byteBuf) {
+                    public void serverConnectionMessage(ChannelId id, MessageSender messageSender,
+                            String sourceIpAddress, ByteBuf byteBuf) {
                         byte[] bytes = new byte[byteBuf.capacity()];
                         byteBuf.getBytes(0, bytes);
                         System.out.println(new String(bytes));
@@ -25,7 +27,7 @@ public class Entrypoint {
                     }
 
                     @Override
-                    public void serverConnectionClosed(ChannelId id) {
+                    public void serverConnectionClosed(ChannelId id, MessageSender messageSender) {
 
                     }
                 });

--- a/src/main/java/com/mycodefu/vsssfshss/server/MessageSender.java
+++ b/src/main/java/com/mycodefu/vsssfshss/server/MessageSender.java
@@ -1,0 +1,8 @@
+package com.mycodefu.vsssfshss.server;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelId;
+
+public interface MessageSender {
+    void sendMessage(ChannelId channel, ByteBuf message);
+}

--- a/src/main/java/com/mycodefu/vsssfshss/server/NettyServer.java
+++ b/src/main/java/com/mycodefu/vsssfshss/server/NettyServer.java
@@ -21,7 +21,7 @@ import io.netty.handler.logging.LogLevel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.util.concurrent.DefaultEventExecutor;
 
-public class NettyServer {
+public class NettyServer implements MessageSender {
     private int initialPort;
     private NioEventLoopGroup bossGroup;
     private NioEventLoopGroup workerGroup;
@@ -47,7 +47,7 @@ public class NettyServer {
                         ChannelPipeline pipeline = ch.pipeline();
                         pipeline.addLast(new HttpServerCodec());
                         pipeline.addLast(new HttpObjectAggregator(65536));
-                        pipeline.addLast(new NettyServerHandler(callback));
+                        pipeline.addLast(new NettyServerHandler(callback, NettyServer.this));
                     }
                 });
     }


### PR DESCRIPTION
This allows the callback to post messages to clients without having to be given a reference to a server object by someone else. This would be tricky as the handler is a constructor parameter of the NettyServer class, and therefore cannot be given to the callbac until afterwards, which gets a bit wierd.